### PR TITLE
[CLEANUP] unify assertion exports

### DIFF
--- a/src/alert.js
+++ b/src/alert.js
@@ -1,14 +1,7 @@
 import { findObject } from 'semantic-dom-selectors';
 import buildAsserter from './assertions/index';
 
-QUnit.extend(QUnit.assert, {
-  // eslint-disable-next-line no-unused-vars
-  alert(label) {
-
-  },
-});
-
-export default function button(label) {
+export default function(label) {
   const control = findObject("[role='alert']", label, 'alert');
   return buildAsserter(control, { label });
 }

--- a/src/button.js
+++ b/src/button.js
@@ -1,7 +1,7 @@
 import { findButton } from 'semantic-dom-selectors';
 import buildAsserter from './assertions/index';
 
-export default function button(label) {
+export default function(label) {
   const control = findButton(label);
   return buildAsserter(control, { label });
 }

--- a/src/input.js
+++ b/src/input.js
@@ -1,9 +1,7 @@
 import { findControl } from 'semantic-dom-selectors';
 import buildAsserter from './assertions/index';
 
-export default function input(label) {
+export default function(label) {
   const control = findControl(label);
-  const asserter = buildAsserter(control, { label });
-
-  return asserter;
+  return buildAsserter(control, { label });
 }

--- a/src/link.js
+++ b/src/link.js
@@ -1,8 +1,7 @@
-export default function link(label) {
+export default function(label) {
   const asserter = QUnit.assert.button(label);
   asserter.href = function (link) {
     this.hasAttribute('href', link);
   };
-
   return asserter;
 }

--- a/src/progress-bar.js
+++ b/src/progress-bar.js
@@ -1,7 +1,7 @@
 import { findObject } from 'semantic-dom-selectors';
 import buildAsserter from './assertions/index';
 
-export default function progress(label) {
+export default function(label) {
   const control = findObject("[role='progressbar']", label);
   const asserter = buildAsserter(control, { label });
   asserter.valueNow = function (value) {


### PR DESCRIPTION
Since we are exporting the assertions in their individual files, 
and extending **qunit assertion** at `index.js`, 

We should clean up and unify each assertion file.