### PR TITLE
[FEATURE] add definition list assertion to qunit

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 import alert from './src/alert';
 import button from './src/button';
+import definitionList from './src/definition-list';
 import input from './src/input';
 import modal from './src/modal';
 import progress from './src/progress-bar';
@@ -8,6 +9,7 @@ export default function(){
   QUnit.extend(QUnit.assert, {
     alert,
     button,
+    definitionList,
     input,
     get modal(){
       return modal(...arguments)

--- a/src/definition-list.js
+++ b/src/definition-list.js
@@ -1,0 +1,30 @@
+import { findControl } from 'semantic-dom-selectors';
+import buildAsserter from './assertions/index';
+
+export default function(label) {
+  //TODO: convert findObject to findDefinitionList (in semantic dom selector)
+  const definitionList = findObject('dl', label, 'definitionList');
+
+  let definitionListAsserter = buildAsserter(definitionList, { label });
+  definitionListAsserter.hasTerm = function(term) {
+    //TODO: convert to within & findDefinitionTerm (in semantic dom selector)
+    let definitionTermElements = [...definitionList.querySelectorAll('dt')].find((element) => {
+      return element.innerText.trim() === term;
+    });
+    //TODO: remove ambiguous message after migrated to findObject
+    if (definitionTermElements && definitionTermElements.length > 1) {
+      throw new Error(`Multiple "${term}" definition terms were found inside "${label}" definition list`);
+    }
+
+    const definitionTermElement = definitionTermElements ? definitionTermElements[0] : undefined;
+    let definitionTermAsserter = buildAsserter(definitionTermElement, { term });
+    definitionTermAsserter.withDefinition = function(definition) {
+      //TODO: convert to within & findDefinitionDefinition (in semantic dom selector)
+      const definitionDefinitionElement = definitionTermElement.nextElementSibling;
+
+      return buildAsserter(definitionDefinitionElement, { definition });
+    };
+    return definitionTermAsserter;
+  };
+  return definitionListAsserter;
+}


### PR DESCRIPTION
To add support for definition list assertion.

#### Usage
```js
assert.definitionList('My Definition List').exist();
assert.definitionList('My Definition List').hasTerm('My Term').exist();
assert.definitionList('My Definition List').hasTerm('My Term')
      .withDefinition('MyDefinition').exist();
```

Follow up issues
- semantic-dom-selectors
  - add support for `findDefinitionList` 
https://github.com/tradegecko/semantic-dom-selectors/issues/24
  - add support for `findDefinitionTerm` 
https://github.com/tradegecko/semantic-dom-selectors/issues/24
  - add support for `findDefinitionDefinition` 
https://github.com/tradegecko/semantic-dom-selectors/issues/24
  - add support for `within` for css selector and dom element 
https://github.com/tradegecko/semantic-dom-selectors/issues/25